### PR TITLE
Use random number in correct range for logfield ID

### DIFF
--- a/logfields.proto
+++ b/logfields.proto
@@ -13,7 +13,7 @@ extend google.protobuf.FieldOptions {
   // context in log messages. This applies when a log message is generated
   // while processing a proto message that contains the field (directly or via
   // an embedded message).
-  LogField logfield = 261337;
+  LogField logfield = 62132;
 }
 
 message LogField {


### PR DESCRIPTION
From descriptor.proto:

> For options which will only be used within a single application or organization, or for experimental options, use field numbers 50000 through 99999.  It is up to you to ensure that you do not use the same number for multiple options.